### PR TITLE
Arcconf Plugin patch: Fix for 'Pools' function

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,11 @@
 News for libStorageMgmt
 
+1.7.3: Feb 15 2019
+    * Bug fixes
+      - https://bugzilla.redhat.com/show_bug.cgi?id=1670077
+      - https://bugzilla.redhat.com/show_bug.cgi?id=1667096
+      - https://bugzilla.redhat.com/show_bug.cgi?id=1667992
+
 1.7.2: Dec 19 2018
     * Bug fixes
       - https://bugzilla.redhat.com/show_bug.cgi?id=1572137

--- a/c_binding/libses.c
+++ b/c_binding/libses.c
@@ -312,7 +312,7 @@ static void _ses_cfg_parse(uint8_t *cfg_data, uint8_t **dp_hdr_begin,
     *dp_hdr_begin = NULL;
 
     cfg_hdr = (struct _ses_cfg_hdr *)cfg_data;
-    end_p = cfg_data + be16toh(cfg_hdr->len_be) + 3;
+    end_p = cfg_data + be16toh(cfg_hdr->len_be) + 4;
     if (end_p >= cfg_data + _SG_T10_SPC_RECV_DIAG_MAX_LEN)
         /* Facing data boundary */
         return;
@@ -462,7 +462,7 @@ static int16_t _ses_find_sas_addr(const char *sas_addr, uint8_t *add_st_data,
     assert(cfg_data != NULL);
 
     add_st = (struct _ses_add_st *) add_st_data;
-    end_p = add_st_data + be16toh(add_st->len_be) + 3;
+    end_p = add_st_data + be16toh(add_st->len_be) + 4;
 
     tmp_p = &add_st->dp_list_begin;
     while(tmp_p < end_p) {
@@ -526,7 +526,7 @@ static int _ses_raw_status_get(char *err_msg, uint8_t *status_data,
     assert(gen_code_be != NULL);
 
     st_hdr = (struct _ses_st_hdr *) status_data;
-    end_p = status_data + be16toh(st_hdr->len_be) + 3;
+    end_p = status_data + be16toh(st_hdr->len_be) + 4;
     status_p = &st_hdr->st_dp_list +
         element_index * _T10_SES_DEV_SLOT_STATUS_LEN;
 
@@ -611,7 +611,7 @@ static int16_t _ses_eiioe(uint8_t *cfg_data, int16_t element_index)
     assert(cfg_data != NULL);
 
     cfg_hdr = (struct _ses_cfg_hdr *)cfg_data;
-    end_p = cfg_data + be16toh(cfg_hdr->len_be) + 3;
+    end_p = cfg_data + be16toh(cfg_hdr->len_be) + 4;
     if (end_p >= cfg_data + _SG_T10_SPC_RECV_DIAG_MAX_LEN)
         /* Facing data boundary */
         return -1;

--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@ dnl Copyright (C) 2011-2016 Red Hat, Inc.
 dnl See COPYING.LIB for the License of this software
 
 AC_INIT(
-    [libstoragemgmt], [1.7.2], [libstoragemgmt-devel@lists.fedorahosted.org],
+    [libstoragemgmt], [1.7.3], [libstoragemgmt-devel@lists.fedorahosted.org],
     [], [https://github.com/libstorage/libstoragemgmt/])
 AC_CONFIG_SRCDIR([configure.ac])
 AC_CONFIG_AUX_DIR([build-aux])

--- a/debian/libstoragemgmt-tools.install
+++ b/debian/libstoragemgmt-tools.install
@@ -1,4 +1,2 @@
 usr/bin/lsmcli
 usr/share/man/man1/lsmcli.1
-usr/libexec/lsm.d/find_unused_lun.py
-usr/libexec/lsm.d/local_sanity_check.py

--- a/doc/man/lsmcli.1.in
+++ b/doc/man/lsmcli.1.in
@@ -157,15 +157,16 @@ Required. Valid values are (case insensitive):
 
 .TP
 \fB--fs\fR \fI<FS_ID>\fR
-Required for \fB--type\fR=\fBSNAPSHOTS\fR, list the snapshots of certain
+Required for \fB--type\fR=\fBSNAPSHOTS\fR, list the snapshots of specific
 filesystem.
-Optional for type \fBEXPORTS\fR, list the NFS export for certain filesystem.
+Optional for type \fBEXPORTS\fR, list the NFS export for specific filesystem.
+Optional for type \fBFS\fR, list specific filesystem.
 .TP
 \fB--sys\fR \fI<SYS_ID>\fR
 Optional.
 Search resources from system with SYS_ID. Only supported when querying these
 types of resources: \fBVOLUMES\fR, \fBPOOLS\fR, \fBFS\fR,
-\fBSNAPSHOTS\fR, \fBDISKS\fR, \fBACCESS_GROUPS\fR, \fBTARGET_PORTS\r,
+\fBDISKS\fR, \fBACCESS_GROUPS\fR, \fBTARGET_PORTS\r,
 \fBBATTERIES\fR.
 .TP
 \fB--pool\fR \fI<POOL_ID>\fR
@@ -364,7 +365,7 @@ Required. The ID of volume to query access.
 
 .SS volume-mask
 .TP 15
-Grant access group RW access to certain volume. Like LUN masking
+Grant access group RW access to specific volume. Like LUN masking
 or NFS export.
 .TP
 \fB--vol\fR \fI<VOL_ID>\fR
@@ -646,7 +647,7 @@ Query RAM cache information for the desired volume.
 Required. ID of the volume to query cache information.
 
 .SS volume-phy-disk-cache-update
-Disable or enable RAM physical disk cache of certain volume.
+Disable or enable RAM physical disk cache of specific volume.
 .TP 15
 \fB--vol\fR \fI<VOL_ID>\fR
 Required. ID of the volume to change.
@@ -655,7 +656,7 @@ Required. ID of the volume to change.
 Required. \fBEnable\fR or \fBDisable\fR.
 
 .SS volume-read-cache-policy-update
-Disable or enable RAM read cache of certain volume.
+Disable or enable RAM read cache of specific volume.
 .TP 15
 \fB--vol\fR \fI<VOL_ID>\fR
 Required. ID of the volume to change.

--- a/plugin/arcconf/arcconf.py
+++ b/plugin/arcconf/arcconf.py
@@ -375,7 +375,14 @@ class Arcconf(IPlugin):
         return rc_lsm_syss
 
     @staticmethod
-    def _arcconf_array_to_lsm_pool(array_id, array_name, sys_id, block_size, total_size, unused_size):
+    def _arcconf_array_to_lsm_pool(arcconf_array):
+        sys_id = arcconf_array['sys_id']
+        array_id = arcconf_array['arrayID']
+        array_name = arcconf_array['arrayName']
+        block_size = arcconf_array['blockSize']
+        total_size = arcconf_array['totalSize']
+        unused_size = arcconf_array['unUsedSpace']
+
         pool_id = '%s:%s' % (sys_id, array_id)
         name = 'Array ' + str(array_name)
         elem_type = Pool.ELEMENT_TYPE_VOLUME | Pool.ELEMENT_TYPE_VOLUME_FULL
@@ -385,7 +392,7 @@ class Arcconf(IPlugin):
 
         status = Pool.STATUS_OK
         status_info = ''
-        plugin_data = {'ctrl_id': sys_id, 'array_id': array_id}
+        plugin_data = pool_id
 
         return Pool(
             pool_id, name, elem_type, unsupported_actions,
@@ -407,14 +414,17 @@ class Arcconf(IPlugin):
             if 'Array' in decoded_json['Controller']:
                 array_infos = decoded_json['Controller']['Array']
                 num_array = len(array_infos)
+                arcconf_array = {}
                 for array in range(num_array):
-                    array_id = array_infos[array]['arrayID']
-                    array_name = array_infos[array]['arrayName']
-                    block_size = array_infos[array]['blockSize']
-                    total_size = array_infos[array]['totalSize']
-                    unused_size = array_infos[array]['unUsedSpace']
+                    arcconf_array['arrayID'] = array_infos[array]['arrayID']
+                    arcconf_array['arrayName'] = array_infos[array]['arrayName']
+                    arcconf_array['blockSize'] = array_infos[array]['blockSize']
+                    arcconf_array['totalSize'] = array_infos[array]['totalSize']
+                    arcconf_array['unUsedSpace'] = \
+                        array_infos[array]['unUsedSpace']
+                    arcconf_array['sys_id'] = sys_id
                     lsm_pools.append(Arcconf._arcconf_array_to_lsm_pool(
-                        array_id, array_name, sys_id, block_size, total_size, unused_size))
+                        arcconf_array))
         return search_property(lsm_pools, search_key, search_value)
 
     @staticmethod

--- a/plugin/megaraid/megaraid.py
+++ b/plugin/megaraid/megaraid.py
@@ -609,6 +609,8 @@ class MegaRAID(IPlugin):
                 plugin_data = "%s:%s" % (
                     ctrl_num, disk_show_basic_dict['EID:Slt'])
                 vpd83 = disk_show_attr_dict["WWN"].lower()
+                if vpd83 == 'na':
+                    vpd = ''
                 rpm = _disk_rpm_of(disk_show_basic_dict)
                 link_type = _disk_link_type_of(disk_show_basic_dict)
 

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/bash
+
+# We are wanting to execute the cmdtest and plugin test against
+# installed packages using the simulator.  This test ensures
+# that a packaged install is working.
+
+function _good
+{
+    echo "executing: $@"
+    eval "$@"
+    local rc=$?
+    if [ $rc -ne 0 ]; then
+        exit 1
+    fi
+}
+
+# Make sure service is running
+systemctl start libstoragemgmt
+
+export LSMCLI_URI="sim://"
+_good python3 cmdtest.py.in -c /usr/bin/lsmcli
+
+export LSM_TEST_URI="sim://"
+_good python3 plugin_test.py.in

--- a/test/trusted.yaml
+++ b/test/trusted.yaml
@@ -14,3 +14,5 @@ REPOS:
 - "https://github.com/cvedel/libstoragemgmt.git"
 - "https://github.com/libstorage/libstoragemgmt.git"
 - "https://github.com/brraghav/libstoragemgmt.git"
+- "https://github.com/sharath-t/libstoragemgmt.git"
+- "https://github.com/hjmallon/libstoragemgmt.git"

--- a/tools/lsmcli/cmdline.py
+++ b/tools/lsmcli/cmdline.py
@@ -422,21 +422,34 @@ size_help = 'Can use B, KiB, MiB, GiB, TiB, PiB postfix (IEC sizing)'
 
 sys_id_opt = dict(name='--sys', metavar='<SYS_ID>', help='System ID')
 sys_id_filter_opt = sys_id_opt.copy()
-sys_id_filter_opt['help'] = 'Search by System ID'
+sys_id_filter_opt['help'] = \
+    'Search by System ID. Only supported for: \n' \
+    '(VOLUMES, POOLS, FS, DISKS, ACCESS_GROUPS,\n' \
+    'TARGET_PORTS, BATTERIES)'
 
 pool_id_opt = dict(name='--pool', metavar='<POOL_ID>', help='Pool ID')
 pool_id_filter_opt = pool_id_opt.copy()
-pool_id_filter_opt['help'] = 'Search by Pool ID'
+pool_id_filter_opt['help'] = \
+    'Search by Pool ID. Only supported for:\n' \
+    '(VOLUMES, POOLS, FS)'
 
 vol_id_opt = dict(name='--vol', metavar='<VOL_ID>', help='Volume ID')
 vol_id_filter_opt = vol_id_opt.copy()
-vol_id_filter_opt['help'] = 'Search by Volume ID'
+vol_id_filter_opt['help'] = \
+    'Search by Volume ID. Only supported for:\n' \
+    '(VOLUMES, ACCESS_GROUPS)'
 
 fs_id_opt = dict(name='--fs', metavar='<FS_ID>', help='File System ID')
+fs_id_filter_opt = fs_id_opt.copy()
+fs_id_filter_opt['help'] = \
+    'Search by FS ID. Only supported for:\n' \
+    '(FS, SNAPSHOTS, EXPORTS)'
 
 ag_id_opt = dict(name='--ag', metavar='<AG_ID>', help='Access Group ID')
 ag_id_filter_opt = ag_id_opt.copy()
-ag_id_filter_opt['help'] = 'Search by Access Group ID'
+ag_id_filter_opt['help'] = \
+    'Search by Access Group ID. Only supported for:\n' \
+    '(ACCESS_GROUPS, VOLUMES)'
 
 init_id_opt = dict(name='--init', metavar='<INIT_ID>', help='Initiator ID',
                    type=_check_init)
@@ -445,15 +458,19 @@ export_id_opt = dict(name='--export', metavar='<EXPORT_ID>', help='Export ID')
 
 nfs_export_id_filter_opt = dict(
     name='--nfs-export', metavar='<NFS_EXPORT_ID>',
-    help='Search by NFS Export ID')
+    help=
+    'Search by NFS Export ID. Only supported for:\n'
+    '(EXPORTS)')
 
 disk_id_filter_opt = dict(name='--disk', metavar='<DISK_ID>',
-                          help='Search by Disk ID')
+                          help='Search by Disk ID. Only supported for:\n'
+                               '(DISKS)')
 
 size_opt = dict(name='--size', metavar='<SIZE>', help=size_help)
 
-tgt_id_opt = dict(name="--tgt", help="Search by target port ID",
-                  metavar='<TGT_ID>')
+tgt_id_filter_opt = dict(name="--tgt", metavar='<TGT_ID>',
+                         help="Search by target port ID.  Only supported for:\n"
+                              "(TARGET_PORTS)")
 
 local_disk_path_opt = dict(name='--path', help="Local disk path",
                            metavar='<DISK_PATH>')
@@ -477,9 +494,9 @@ cmds = (
             dict(vol_id_filter_opt),
             dict(disk_id_filter_opt),
             dict(ag_id_filter_opt),
-            dict(fs_id_opt),
+            dict(fs_id_filter_opt),
             dict(nfs_export_id_filter_opt),
-            dict(tgt_id_opt),
+            dict(tgt_id_filter_opt),
         ],
     ),
 
@@ -831,11 +848,11 @@ cmds = (
             dict(name="--anonuid", metavar='<ANON_UID>',
                  help='UID(User ID) to map to anonymous user',
                  default=NfsExport.ANON_UID_GID_NA,
-                 type=long),
+                 type=_check_positive_integer),
             dict(name="--anongid", metavar='<ANON_GID>',
                  help='GID(Group ID) to map to anonymous user',
                  default=NfsExport.ANON_UID_GID_NA,
-                 type=long),
+                 type=_check_positive_integer),
             dict(name="--auth-type", metavar='<AUTH_TYPE>',
                  help='NFS client authentication type'),
             dict(name="--root-host", metavar='<ROOT_HOST>',


### PR DESCRIPTION
issue: pool ID for array with multiple LDs - number of pools shown is incorrect. current logic is "ctrl ID:LD ID"
		fix: replaced existing logic with logic to read arrayID
		
	issue: total space and free space is displayed as 0
		fix: implemented logic for 'total space = blockSize*totalSize' and 'free space = blockSize*unUsedSpace'